### PR TITLE
Bump lxml from 4.6.3 to 5.3.0 for python >= 3.12

### DIFF
--- a/src/requirements-base.txt
+++ b/src/requirements-base.txt
@@ -1,2 +1,2 @@
-lxml==4.6.3
+lxml==5.3.0
 python-dateutil==2.8.2


### PR DESCRIPTION
lxml==4.6.3 is only supported up to python version 3.11.
From python python version 3.12 on building wheels for lxml will fail with the following error:

```
format -Werror=format-security -fPIC -DCYTHON_CLINE_IN_TRACEBACK=0 -I/usr/include/libxml2 -Isrc -Isrc/lxml/includes -I/app/.heroku/python/include/python3.12 -c src/lxml/etree.c -o build/temp.linux-x86_64-cpython-312/src/lxml/etree.o -w
remote:              src/lxml/etree.c:289:12: fatal error: longintrepr.h: No such file or directory
remote:                289 |   #include "longintrepr.h"
remote:                    |            ^~~~~~~~~~~~~~~
remote:              compilation terminated.
remote:              Compile failed: command '/usr/bin/gcc' failed with exit code 1
remote:              creating tmp
remote:              cc -I/usr/include/libxml2 -I/usr/include/libxml2 -c /tmp/xmlXPathInitdpho_p7f.c -o tmp/xmlXPathInitdpho_p7f.o
remote:              cc tmp/xmlXPathInitdpho_p7f.o -lxml2 -o a.out
remote:              error: command '/usr/bin/gcc' failed with exit code 1
remote:              [end of output]
remote:          
remote:          note: This error originates from a subprocess, and is likely not a problem with pip.
remote:          ERROR: Failed building wheel for lxml
remote:          Running setup.py clean for lxml
remote:        Failed to build lxml
```

This patch fixes capparselib to work with python versions >= 3.12